### PR TITLE
Remove the git cleanup after publication.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,12 +42,7 @@ fn publish(docs_path: &str,
     let mut refspec = String::from("master:");
     refspec.push_str(push_branch);
 
-    try!(git::force_push(docs_path, remote.trim(), &refspec, dry_run));
-
-    // Clean up.
-    call(vec!["rm", "-fr", ".nojekyll", ".git"],
-         &docs_build_path,
-         dry_run)
+    git::force_push(docs_path, remote.trim(), &refspec, dry_run)
 }
 
 fn execute(args: &ArgMatches) -> Result<i32, FatalError> {


### PR DESCRIPTION
Removing the cleanup is useful when working with cargo-sphinx in a Docker
container where your git credentials are not available. Not deleting the git
files means the push can be completed on the host machine instead.

The files are created beneath the _build output directory which is hosed on
the next cargo-sphinx call.