### PR TITLE
Add AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+Daithi O Crualaoich <daithi.ocrualaoich@gmail.com>
+Daniel Goertzen <daniel.goertzen@gmail.com>
+Ning Sun <sunng@about.me>
+Pascal Hartig <i@passy.me>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,7 +153,7 @@ You may licence this work under the Apache License, Version 2.0.
 
 ::
 
-    Copyright 2016 Ning Sun and tojson_macros contributors
+    Copyright 2016 Cargo Sphinx Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ Alternatively, you may licence this work under the MIT Licence at your option.
 
 ::
 
-    Copyright (c) 2016 Ning Sun and tojson_macros contributors
+    Copyright (c) 2016 Cargo Sphinx Contributors
     
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The Rust project does something similar itself, but without keeping a
separate text file. I think it's a bit nicer to mention everyone
explicitly, especially since we don't have thousands of contributors.