### PR TITLE
Cargo Shell integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,10 @@ cache: cargo
 notifications:
   slack:
     secure: cJlI7yad4btGDvHCBYzIhIp9/TgHaRSDCWX8JQfEbrnurRFhfQcULVmqTXyUVsYxlXu0sDYIf4udRTZkKZJ+XTg6bdo7Q29Nk7BrtOsNDGKUokCCKel22FsNTONHL5BS8ScKKTur40OXQFUv7YaiEc5B3yYWjV4K6a6nsCldV0r9bevKxRnJlP1OxD/euB8m1aD9gLP6K9XNn7wBSuZsWv3chr3ordq11T+MsBiTWlIK3qOg8GDI7XRioJDdmfxZ262joUsZSQ7Zd090GRKTwIus96EfjHGNb2wDIcltfjJrtcO7zSj/F8Fqef9SqT/1XBHpzLlkb8admSLs/0ArEv1+1a+qhqhnTXFyEQB25+SneuX+FbwcEy6zfLEk4pVkFoAj5SJmGnb4hiEEBKSvx2/2lraeHkgDpjPT7Io387VwIugbxGB6Ch2NDDIHl8ZzAzz9pGEsMUlZzbpTSR1KCiRdzcu7x1ojduUKFwXU7OLiuXdTF0WI9klFEBWp1OW2i0LMSrZ9y1R99MPqOwwnKHhphhgTu4P3xh6AENSDoDIJOIxlp+hLyl6GHU5n1B67DZEw2sCbwZACeEhRcjtf8nXcyNsqmqUDS0ssPaGo4a99/FOTbv85NWOZGZAR5wKF/4T1338JAcanIaLoCMJ6Ij5zE/nLc0loYESWWntNsYQ=
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+    packages:
+      - cmake
+      - libssl-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "cargo 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,27 @@
 name = "cargo-sphinx"
 version = "0.1.0"
 dependencies = [
+ "cargo 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -14,7 +32,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crates-io 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.83 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2-curl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -33,13 +95,329 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crates-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "curl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "filetime"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fs2"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gdi32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git2-curl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curl 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -48,9 +426,44 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tar"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xattr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "term_size"
@@ -61,12 +474,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
@@ -79,7 +530,57 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "url"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "user32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xattr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ readme = "README.md"
 toml = "0.2.0"
 quick-error = "1.1.0"
 clap = "2.10.4"
+cargo = "0.12.0"
 
-[package.metadata.sphinx]   
+
+[package.metadata.sphinx]
 docs-path = "docs"
 commit-message = "(cargo-sphinx) Generate docs."
 sign-commit = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ toml = "0.2.0"
 quick-error = "1.1.0"
 clap = "2.10.4"
 cargo = "0.12.0"
-
+term = "0.4.4"
 
 [package.metadata.sphinx]
 docs-path = "docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ commit-message = "(cargo-sphinx) Generate docs."
 sign-commit = false
 push-remote = "origin"
 push-branch = "gh-pages"
+
+[profile.dev]
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ commit-message = "(cargo-sphinx) Generate docs."
 sign-commit = false
 push-remote = "origin"
 push-branch = "gh-pages"
-
-[profile.dev]
-lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN     pip install cloud_sptheme
 # Rust
 ################################################################################
 
-RUN    apt-get install -qq curl graphviz
+RUN    apt-get install -qq curl graphviz cmake libssl-dev
 
 RUN    curl https://sh.rustup.rs -sSf | env RUSTUP_INIT_SKIP_SUDO_CHECK=1 sh -s -- -y
 ENV    CARGO_TARGET_DIR targetdocker

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -43,10 +43,8 @@ pub fn call(command: Vec<&str>,
             let output = try!(cmd.output());
             if !output.status.success() {
                 try!(shell.error(String::from_utf8_lossy(&output.stderr)));
-                Ok(false)
-            } else {
-                Ok(true)
             }
+            Ok(output.status.success())
         }
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,15 +1,22 @@
 use std::process::Command;
 use error::FatalError;
+use cargo::core::MultiShell;
+use cargo::core::shell::Verbosity::{Verbose, Normal, Quiet};
+use term::color;
 
 ///
 /// Shell out and execute the specified command. Change to the path first and
 /// only execute the command if a dry run has not been requested.
 ///
-pub fn call(command: Vec<&str>, path: &str, dry_run: bool) -> Result<bool, FatalError> {
+pub fn call(command: Vec<&str>,
+            path: &str,
+            shell: &mut MultiShell,
+            dry_run: bool)
+            -> Result<bool, FatalError> {
     if dry_run {
-        println!("cd {}", path);
-        println!("{}", command.join(" "));
-        println!("cd -");
+        try!(shell.say(format!("cd {}", path), color::GREEN));
+        try!(shell.say(format!("{}", command.join(" ")), color::GREEN));
+        try!(shell.say("cd -", color::GREEN));
 
         return Ok(true);
     }
@@ -26,8 +33,20 @@ pub fn call(command: Vec<&str>, path: &str, dry_run: bool) -> Result<bool, Fatal
         }
     }
 
-    let mut child = try!(cmd.spawn());
-    let result = try!(child.wait());
-
-    Ok(result.success())
+    match shell.get_verbose() {
+        Verbose | Normal => {
+            let mut child = try!(cmd.spawn());
+            let result = try!(child.wait());
+            Ok(result.success())
+        }
+        Quiet => {
+            let output = try!(cmd.output());
+            if !output.status.success() {
+                try!(shell.error(String::from_utf8_lossy(&output.stderr)));
+                Ok(false)
+            } else {
+                Ok(true)
+            }
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::io::Error as IOError;
 use std::string::FromUtf8Error;
+use cargo::CargoError;
 
 quick_error! {
     #[derive(Debug)]
@@ -15,6 +16,10 @@ quick_error! {
         UnknownCargoFileKey {
             display("Unknown cargo key found")
             description("Unknown config key found")
+        }
+        CargoError(err: Box<CargoError>) {
+            from()
+            cause(err)
         }
         FromUtf8Error(err: FromUtf8Error) {
             from()

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use cmd::call;
 use error::FatalError;
+use cargo::core::MultiShell;
 
 pub fn remote_get_url(remote: &str) -> Result<String, FatalError> {
     let output = try!(Command::new("git")
@@ -14,24 +15,34 @@ pub fn remote_get_url(remote: &str) -> Result<String, FatalError> {
     Ok(url)
 }
 
-pub fn init(dir: &str, dry_run: bool) -> Result<bool, FatalError> {
-    call(vec!["git", "init"], dir, dry_run)
+pub fn init(dir: &str, shell: &mut MultiShell, dry_run: bool) -> Result<bool, FatalError> {
+    call(vec!["git", "init"], dir, shell, dry_run)
 }
 
-pub fn add_all(dir: &str, dry_run: bool) -> Result<bool, FatalError> {
-    call(vec!["git", "add", "."], dir, dry_run)
+pub fn add_all(dir: &str, shell: &mut MultiShell, dry_run: bool) -> Result<bool, FatalError> {
+    call(vec!["git", "add", "."], dir, shell, dry_run)
 }
 
-pub fn commit_all(dir: &str, msg: &str, sign: bool, dry_run: bool) -> Result<bool, FatalError> {
+pub fn commit_all(dir: &str,
+                  msg: &str,
+                  sign: bool,
+                  shell: &mut MultiShell,
+                  dry_run: bool)
+                  -> Result<bool, FatalError> {
     call(vec!["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
          dir,
+         shell,
          dry_run)
 }
 
 pub fn force_push(dir: &str,
                   remote: &str,
                   refspec: &str,
+                  shell: &mut MultiShell,
                   dry_run: bool)
                   -> Result<bool, FatalError> {
-    call(vec!["git", "push", "-f", remote, refspec], dir, dry_run)
+    call(vec!["git", "push", "-f", remote, refspec],
+         dir,
+         shell,
+         dry_run)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,9 @@ use config::Config;
 use error::FatalError;
 use term::color;
 
-fn build(docs_path: &str, dry_run: bool) -> Result<(), FatalError> {
+fn build(docs_path: &str, shell: &mut MultiShell, dry_run: bool) -> Result<(), FatalError> {
     try!(shell.say("Building Sphinx docs.", color::BLUE));
-    try!(call(vec!["make", "clean", "html"], docs_path, dry_run));
+    try!(call(vec!["make", "clean", "html"], docs_path, shell, dry_run));
 
     // A `.nojekyll` file prevents GitHub from ignoring Sphinx CSS files.
     let nojekyll = Path::new(docs_path).join("_build/html/.nojekyll");
@@ -41,20 +41,21 @@ fn publish(docs_path: &str,
            sign: bool,
            push_remote: &str,
            push_branch: &str,
+           shell: &mut MultiShell,
            dry_run: bool)
            -> Result<bool, FatalError> {
-    println!("Publishing Sphinx docs to GitHub Pages.");
+    try!(shell.say("Publishing Sphinx docs to GitHub Pages.", color::BLUE));
     let docs_build_path = format!("{}/_build/html", docs_path);
 
-    try!(git::init(&docs_build_path, dry_run));
-    try!(git::add_all(&docs_build_path, dry_run));
-    try!(git::commit_all(&docs_build_path, commit_msg, sign, dry_run));
+    try!(git::init(&docs_build_path, shell, dry_run));
+    try!(git::add_all(&docs_build_path, shell, dry_run));
+    try!(git::commit_all(&docs_build_path, commit_msg, sign, shell, dry_run));
     let remote = try!(git::remote_get_url(push_remote));
 
     let mut refspec = String::from("master:");
     refspec.push_str(push_branch);
 
-    git::force_push(docs_path, remote.trim(), &refspec, dry_run)
+    git::force_push(docs_path, remote.trim(), &refspec, shell, dry_run)
 }
 
 fn execute(args: &ArgMatches, cargo_config: &CargoConfig) -> Result<i32, FatalError> {
@@ -95,6 +96,7 @@ fn execute(args: &ArgMatches, cargo_config: &CargoConfig) -> Result<i32, FatalEr
                      sign,
                      push_remote,
                      push_branch,
+                     &mut *cargo_config.shell(),
                      dry_run));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
+extern crate cargo;
+extern crate clap;
 #[macro_use]
 extern crate quick_error;
+extern crate term;
 extern crate toml;
-extern crate clap;
 
 use std::fs::File;
 use std::path::Path;
 use std::process::exit;
 
 use clap::{App, ArgMatches, SubCommand};
+use cargo::util::Config as CargoConfig;
+use cargo::core::MultiShell;
 
 mod config;
 mod error;
@@ -17,9 +21,10 @@ mod git;
 use cmd::call;
 use config::Config;
 use error::FatalError;
+use term::color;
 
 fn build(docs_path: &str, dry_run: bool) -> Result<(), FatalError> {
-    println!("Building Sphinx docs.");
+    try!(shell.say("Building Sphinx docs.", color::BLUE));
     try!(call(vec!["make", "clean", "html"], docs_path, dry_run));
 
     // A `.nojekyll` file prevents GitHub from ignoring Sphinx CSS files.
@@ -52,7 +57,11 @@ fn publish(docs_path: &str,
     git::force_push(docs_path, remote.trim(), &refspec, dry_run)
 }
 
-fn execute(args: &ArgMatches) -> Result<i32, FatalError> {
+fn execute(args: &ArgMatches, cargo_config: &CargoConfig) -> Result<i32, FatalError> {
+    try!(cargo_config.configure_shell(args.occurrences_of("verbose") as u32,
+                                      Some(args.is_present("quiet")),
+                                      &args.value_of("color").map(|s| String::from(s))));
+
     let config: Config = try!(Config::from("Cargo.toml"));
 
     // Find parameters or use defaults.
@@ -79,7 +88,7 @@ fn execute(args: &ArgMatches) -> Result<i32, FatalError> {
         .unwrap_or("gh-pages");
 
     // Generate and publish documentation.
-    try!(build(docs_path, dry_run));
+    try!(build(docs_path, &mut *cargo_config.shell(), dry_run));
     if push {
         try!(publish(docs_path,
                      commit_msg,
@@ -103,6 +112,9 @@ fn main() {
             .arg_from_usage("--dry-run 'Print commands to execute instead of running.'")
             .arg_from_usage("-p, --push 'Push generated documentation to git remote.'")
             .arg_from_usage("-s, --sign 'Sign the git commit.'")
+            .arg_from_usage("-v, --verbose 'Use verbose output.'")
+            .arg_from_usage("-q, --quiet 'Less output printed to stdout.'")
+            .arg_from_usage("--color 'Coloring: auto, always, never.'")
             .arg_from_usage("--docs-path=[STRING] 'Path of Sphinx documentation to build. \
                              Defaults to `docs` if not specified.'")
             .arg_from_usage("--commit-message=[STRING] 'Commit message for the documentation \
@@ -114,11 +126,13 @@ fn main() {
                              Defaults to `gh-pages` if not specified.'"))
         .get_matches();
 
+    let cargo_config = CargoConfig::default().expect("Unable to get config");
+
     if let Some(sphinx_matches) = matches.subcommand_matches("sphinx") {
-        match execute(sphinx_matches) {
+        match execute(sphinx_matches, &cargo_config) {
             Ok(code) => exit(code),
             Err(e) => {
-                println!("Fatal: {}", e);
+                cargo_config.shell().error(format!("Fatal: {}", e)).unwrap();
                 exit(128);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use error::FatalError;
 use term::color;
 
 fn build(docs_path: &str, shell: &mut MultiShell, dry_run: bool) -> Result<(), FatalError> {
-    try!(shell.say("Building Sphinx docs.", color::BLUE));
+    try!(shell.verbose(|s| s.say("Building Sphinx docs.", color::BLUE)));
     try!(call(vec!["make", "clean", "html"], docs_path, shell, dry_run));
 
     // A `.nojekyll` file prevents GitHub from ignoring Sphinx CSS files.
@@ -44,7 +44,7 @@ fn publish(docs_path: &str,
            shell: &mut MultiShell,
            dry_run: bool)
            -> Result<bool, FatalError> {
-    try!(shell.say("Publishing Sphinx docs to GitHub Pages.", color::BLUE));
+    try!(shell.verbose(|s| s.say("Publishing Sphinx docs to GitHub Pages.", color::BLUE)));
     let docs_build_path = format!("{}/_build/html", docs_path);
 
     try!(git::init(&docs_build_path, shell, dry_run));


### PR DESCRIPTION
I'd like to make this a better citizen of Cargo Republic. The internal commands as well as a lot of cargo extensions make use of Cargo's multishell which knows about verbosity and quiet modes as well as colors.

Ultimate, I'd like to get rid of all `println!` statements and make sure that we shut `sphinx` up if we pass the `-q/--quiet` flag. It also gives us some opportunity to use color when we (cargo-sphinx) are talking as opposed to sphinx.

So far, this patch pulls in Cargo, configures its shell, and uses the MultiShell for printing fatal errors and the build message.

This does, however, add quite a bit to the build time. I haven't tried enabling LOT yet, I guess it should help. It also adds libssl-dev as build-time dependency.

Another thing I haven't investigated yet is whether we could possibly unify the configs instead of having two.