### PR TITLE
Remove i686-pc-windows-gnu appveyor target

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - TARGET: x86_64-pc-windows-msvc
     - TARGET: i686-pc-windows-msvc
-    - TARGET: i686-pc-windows-gnu
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.11.0-${env:TARGET}.exe"


### PR DESCRIPTION
It doesn't seem to come with cmake. The other two do.