### PR TITLE
Upgrade AppVeyor Rust version to 1.20

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,8 @@ environment:
     - TARGET: i686-pc-windows-msvc
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.11.0-${env:TARGET}.exe"
-  - rust-1.11.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.20.0-${env:TARGET}.exe"
+  - rust-1.20.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V


### PR DESCRIPTION
Seems to be building okay again. Please let's merge this quickly so I can stop pretending to care about Windoze again.