### PR TITLE
Port from error_chain to failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "cargo-sphinx"
-version = "1.1.0"
-dependencies = [
- "cargo 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "advapi32-sys"
 version = "0.2.0"
@@ -44,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -105,22 +94,34 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo-sphinx"
+version = "1.1.0"
+dependencies = [
+ "cargo 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -149,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,9 +180,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -198,7 +199,7 @@ dependencies = [
  "curl-sys 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -211,7 +212,7 @@ dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,10 +232,10 @@ name = "docopt"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -257,7 +258,25 @@ name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -281,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -324,7 +343,7 @@ dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -350,7 +369,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -409,7 +428,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -423,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -437,12 +456,12 @@ version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl-sys 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -451,10 +470,10 @@ name = "libssh2-sys"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -542,14 +561,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -559,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -570,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -588,18 +607,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,7 +680,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -676,22 +690,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -703,18 +717,18 @@ name = "serde_ignored"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -758,12 +772,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tar"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -771,7 +795,7 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -805,7 +829,7 @@ name = "thread_local"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -814,7 +838,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -855,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -930,7 +954,7 @@ dependencies = [
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
-"checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
+"checksum backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8709cc7ec06f6f0ae6c2c7e12f6ed41540781f72b488d83734978295ceae182e"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
@@ -938,7 +962,7 @@ dependencies = [
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
-"checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
+"checksum cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e14cd15a7cbc2c6a905677e54b831ee91af2ff43b352010f6133236463b65cac"
 "checksum core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5909502e547762013619f4c4e01cc7393c20fe2d52d7fa471c1210adb2320dc7"
 "checksum core-foundation-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9fb3d6cb663e6fd7cf1c63f9b144ee2b1e4a78595a0451dd34bff85b9a3387"
 "checksum crates-io 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "10ff1f960239350faf43a5ae9a2cecb92dd90d99a6578ffa5c9ca558071aa750"
@@ -950,9 +974,11 @@ dependencies = [
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76aa046667594883228b6c1f55c260425950a5cdc66d3aa09c30472d5ac6e70c"
+"checksum failure_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7223de85610caf0791730aa6f23360f9826ff570a03aa295f3f58bcf7e050f05"
 "checksum filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "aa75ec8f7927063335a9583e7fa87b0110bb888cf766dc01b54c0ff70d760c8e"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
-"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
@@ -968,7 +994,7 @@ dependencies = [
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum jobserver 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "931b04e5e57d88cc909528f0d701db36a870b72a052648ded8baf80f9f445e0f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libgit2-sys 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "6f74b4959cef96898f5123148724fc7dee043b9a6b99f219d948851bfbe53cb2"
 "checksum libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0db4ec23611747ef772db1c4d650f8bd762f07b461727ec998f953c614024b75"
@@ -982,15 +1008,14 @@ dependencies = [
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf434ff6117485dc16478d77a4f5c84eccc9c3645c4da8323b287ad6a15a638"
+"checksum openssl 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "2225c305d8f57001a0d34263e046794aa251695f20773102fbbfeb1e7b189955"
 "checksum openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98df0270d404ccd3c050a41d579c52d1db15375168bb3471e04ec0f5f378daf"
-"checksum openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad395f1cee51b64a8d07cc8063498dc7554db62d5f3ca87a67f4eed2791d0c8"
-"checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
+"checksum openssl-sys 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "92867746af30eea7a89feade385f7f5366776f1c52ec6f0de81360373fa88363"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum psapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abcd5d1a07d360e29727f757a9decb3ce8bc6e0efa8969cfaad669a8317a2478"
-"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
+"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
@@ -1001,17 +1026,18 @@ dependencies = [
 "checksum scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59a076157c1e2dc561d8de585151ee6965d910dd4dcb5dabb7ae3e83981a6c57"
 "checksum semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdd61b85a0fa777f7fb7c454b9189b2941b110d1385ce84d7f76efdf1606a85"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "395993cac4e3599c7c1b70a6a92d3b3f55f4443df9f0b5294e362285ad7c9ecb"
-"checksum serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa060f679fe2d5a9f7374dd4553dc907eba4f9acf183e4c7baf69eae02e6ca8"
-"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6eda663e865517ee783b0891a3f6eb3a253e0b0dabb46418969ee9635beadd9e"
+"checksum serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "652bc323d694dc925829725ec6c890156d8e70ae5202919869cb00fe2eff3788"
+"checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
 "checksum serde_ignored 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c10e798e4405d7dcec3658989e35ee6706f730a9ed7c1184d5ebd84317e82f46"
-"checksum serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1e67ce320daa7e494c578e34d4b00689f23bb94512fe0ca0dfaf02ea53fb67"
+"checksum serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e4586746d1974a030c48919731ecffd0ed28d0c40749d0d18d43b3a7d6c9b20e"
 "checksum shell-escape 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dd5cc96481d54583947bfe88bf30c23d53f883c6cd0145368b69989d97b84ef8"
 "checksum socket2 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b4896961171cd3317c7e9603d88f379f8c6e45342212235d356496680c68fd"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "281285b717926caa919ad905ef89c63d75805c7d89437fb873100925a53f2b1b"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
+"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9065bced9c3e43453aa3d56f1e98590b8455b341d2fa191a1090c0dd0b242c75"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ include = [
 
 [dependencies]
 toml = "0.4.5"
-quick-error = "1.2.1"
+failure = "0.1.0"
+failure_derive = "0.1.0"
 clap = "2.26.2"
 cargo = "0.22.0"
 termcolor = "0.3.3"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -10,12 +10,19 @@ use termcolor::Color::Green;
 ///
 pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     if dry_run {
-        try!(shell.status_with_color("", format!("cd {}", path), Green)
-                  .map_err(SyncFailure::new));
-        try!(shell.status_with_color("", format!("{}", command.join(" ")), Green)
-                  .map_err(SyncFailure::new));
-        try!(shell.status_with_color("", "cd -", Green)
-                  .map_err(SyncFailure::new));
+        try!(
+            shell
+                .status_with_color("", format!("cd {}", path), Green)
+                .map_err(SyncFailure::new)
+        );
+        try!(
+            shell
+                .status_with_color("", format!("{}", command.join(" ")), Green)
+                .map_err(SyncFailure::new)
+        );
+        try!(shell.status_with_color("", "cd -", Green).map_err(
+            SyncFailure::new,
+        ));
 
         return Ok(true);
     }
@@ -41,8 +48,11 @@ pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> R
         Quiet => {
             let output = try!(cmd.output());
             if !output.status.success() {
-                try!(shell.error(String::from_utf8_lossy(&output.stderr))
-                          .map_err(SyncFailure::new));
+                try!(
+                    shell
+                        .error(String::from_utf8_lossy(&output.stderr))
+                        .map_err(SyncFailure::new)
+                );
             }
             Ok(output.status.success())
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,5 +1,5 @@
 use cargo::core::shell::Shell;
-use cargo::core::shell::Verbosity::{Verbose, Normal, Quiet};
+use cargo::core::shell::Verbosity::{Normal, Quiet, Verbose};
 use failure::{Error, SyncFailure};
 use std::process::Command;
 use termcolor::Color::Green;
@@ -8,20 +8,23 @@ use termcolor::Color::Green;
 /// Shell out and execute the specified command. Change to the path first and
 /// only execute the command if a dry run has not been requested.
 ///
-pub fn call(
-    command: &[&str],
-    path: &str,
-    shell: &mut Shell,
-    dry_run: bool,
-) -> Result<bool, Error> {
+pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     if dry_run {
-        try!(shell.status_with_color("", format!("cd {}", path), Green).map_err(SyncFailure::new));
-        try!(shell.status_with_color(
-            "",
-            format!("{}", command.join(" ")),
-            Green,
-        ).map_err(SyncFailure::new));
-        try!(shell.status_with_color("", "cd -", Green).map_err(SyncFailure::new));
+        try!(
+            shell
+                .status_with_color("", format!("cd {}", path), Green)
+                .map_err(SyncFailure::new)
+        );
+        try!(
+            shell
+                .status_with_color("", format!("{}", command.join(" ")), Green)
+                .map_err(SyncFailure::new)
+        );
+        try!(
+            shell
+                .status_with_color("", "cd -", Green)
+                .map_err(SyncFailure::new)
+        );
 
         return Ok(true);
     }
@@ -47,7 +50,11 @@ pub fn call(
         Quiet => {
             let output = try!(cmd.output());
             if !output.status.success() {
-                try!(shell.error(String::from_utf8_lossy(&output.stderr)).map_err(SyncFailure::new));
+                try!(
+                    shell
+                        .error(String::from_utf8_lossy(&output.stderr))
+                        .map_err(SyncFailure::new)
+                );
             }
             Ok(output.status.success())
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -10,21 +10,12 @@ use termcolor::Color::Green;
 ///
 pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     if dry_run {
-        try!(
-            shell
-                .status_with_color("", format!("cd {}", path), Green)
-                .map_err(SyncFailure::new)
-        );
-        try!(
-            shell
-                .status_with_color("", format!("{}", command.join(" ")), Green)
-                .map_err(SyncFailure::new)
-        );
-        try!(
-            shell
-                .status_with_color("", "cd -", Green)
-                .map_err(SyncFailure::new)
-        );
+        try!(shell.status_with_color("", format!("cd {}", path), Green)
+                  .map_err(SyncFailure::new));
+        try!(shell.status_with_color("", format!("{}", command.join(" ")), Green)
+                  .map_err(SyncFailure::new));
+        try!(shell.status_with_color("", "cd -", Green)
+                  .map_err(SyncFailure::new));
 
         return Ok(true);
     }
@@ -50,11 +41,8 @@ pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> R
         Quiet => {
             let output = try!(cmd.output());
             if !output.status.success() {
-                try!(
-                    shell
-                        .error(String::from_utf8_lossy(&output.stderr))
-                        .map_err(SyncFailure::new)
-                );
+                try!(shell.error(String::from_utf8_lossy(&output.stderr))
+                          .map_err(SyncFailure::new));
             }
             Ok(output.status.success())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,9 @@ impl Config {
 
         for key in config.keys() {
             if !valid_keys.contains(&key.as_ref()) {
-                return Err(FatalError::UnknownCargoFileKey { key: key.to_string() });
+                return Err(FatalError::UnknownCargoFileKey {
+                    key: key.to_string(),
+                });
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,23 +71,26 @@ impl Config {
         // Verify parsed TOML is valid.
         let mut toml: Table = try!(parsed.ok_or(FatalError::InvalidCargoFileFormat));
 
-        let config: Table = toml.remove("package").and_then(Config::value_to_table)
-                                .and_then(|mut table| table.remove("metadata"))
-                                .and_then(Config::value_to_table)
-                                .and_then(|mut table| table.remove("sphinx"))
-                                .and_then(Config::value_to_table)
-                                .unwrap_or_default();
+        let config: Table = toml.remove("package")
+            .and_then(Config::value_to_table)
+            .and_then(|mut table| table.remove("metadata"))
+            .and_then(Config::value_to_table)
+            .and_then(|mut table| table.remove("sphinx"))
+            .and_then(Config::value_to_table)
+            .unwrap_or_default();
 
         // Verify the Cargo Sphinx TOML configuration.
-        let valid_keys = vec![DOCS_PATH,
-                              COMMIT_MESSAGE,
-                              SIGN_COMMIT,
-                              PUSH_REMOTE,
-                              PUSH_BRANCH];
+        let valid_keys = vec![
+            DOCS_PATH,
+            COMMIT_MESSAGE,
+            SIGN_COMMIT,
+            PUSH_REMOTE,
+            PUSH_BRANCH,
+        ];
 
         for key in config.keys() {
             if !valid_keys.contains(&key.as_ref()) {
-                return Err(FatalError::UnknownCargoFileKey { key: key.to_string(), });
+                return Err(FatalError::UnknownCargoFileKey { key: key.to_string() });
             }
         }
 
@@ -125,8 +128,10 @@ fn test_commit_message_config() {
     let result: Result<Config, FatalError> = Config::from("Cargo.toml");
     let config: Config = result.expect("Parse cargo file failed.");
 
-    assert_eq!(config.get_str("commit-message"),
-               Some("(cargo-sphinx) Generate docs."));
+    assert_eq!(
+        config.get_str("commit-message"),
+        Some("(cargo-sphinx) Generate docs.")
+    );
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,6 @@ use toml::Value;
 use toml::value::Table;
 use error::FatalError;
 
-
 ///
 /// `Cargo.toml` key under `package.metadata.sphinx` for specifying a default
 /// location for the project Sphinx documentation files.
@@ -65,7 +64,7 @@ impl Config {
     ///
     pub fn from(path: &str) -> Result<Config, FatalError> {
         let path = Path::new(path);
-        let contents = try!(Config::load_from_file(path));
+        let contents = try!(Config::load_from_file(path).map_err(|e| FatalError::IO(e)));
 
         let parsed: Option<Table> = toml::from_str(&contents).ok();
 
@@ -91,7 +90,7 @@ impl Config {
 
         for key in config.keys() {
             if !valid_keys.contains(&key.as_ref()) {
-                return Err(FatalError::UnknownCargoFileKey(key.to_string()));
+                return Err(FatalError::UnknownCargoFileKey { key: key.to_string() });
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,28 +71,23 @@ impl Config {
         // Verify parsed TOML is valid.
         let mut toml: Table = try!(parsed.ok_or(FatalError::InvalidCargoFileFormat));
 
-        let config: Table = toml.remove("package")
-            .and_then(Config::value_to_table)
-            .and_then(|mut table| table.remove("metadata"))
-            .and_then(Config::value_to_table)
-            .and_then(|mut table| table.remove("sphinx"))
-            .and_then(Config::value_to_table)
-            .unwrap_or_default();
+        let config: Table = toml.remove("package").and_then(Config::value_to_table)
+                                .and_then(|mut table| table.remove("metadata"))
+                                .and_then(Config::value_to_table)
+                                .and_then(|mut table| table.remove("sphinx"))
+                                .and_then(Config::value_to_table)
+                                .unwrap_or_default();
 
         // Verify the Cargo Sphinx TOML configuration.
-        let valid_keys = vec![
-            DOCS_PATH,
-            COMMIT_MESSAGE,
-            SIGN_COMMIT,
-            PUSH_REMOTE,
-            PUSH_BRANCH,
-        ];
+        let valid_keys = vec![DOCS_PATH,
+                              COMMIT_MESSAGE,
+                              SIGN_COMMIT,
+                              PUSH_REMOTE,
+                              PUSH_BRANCH];
 
         for key in config.keys() {
             if !valid_keys.contains(&key.as_ref()) {
-                return Err(FatalError::UnknownCargoFileKey {
-                    key: key.to_string(),
-                });
+                return Err(FatalError::UnknownCargoFileKey { key: key.to_string(), });
             }
         }
 
@@ -130,10 +125,8 @@ fn test_commit_message_config() {
     let result: Result<Config, FatalError> = Config::from("Cargo.toml");
     let config: Config = result.expect("Parse cargo file failed.");
 
-    assert_eq!(
-        config.get_str("commit-message"),
-        Some("(cargo-sphinx) Generate docs.")
-    );
+    assert_eq!(config.get_str("commit-message"),
+               Some("(cargo-sphinx) Generate docs."));
 }
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,9 +2,15 @@ use std::io::Error as IOError;
 
 #[derive(Fail, Debug)]
 pub enum FatalError {
-    #[fail(display = "{}", _0)] IO(#[cause] IOError),
+    #[fail(display = "{}", _0)]
+    IO(
+        #[cause]
+        IOError
+    ),
 
-    #[fail(display = "Invalid cargo file format.")] InvalidCargoFileFormat,
+    #[fail(display = "Invalid cargo file format.")]
+    InvalidCargoFileFormat,
 
-    #[fail(display = "Unknown cargo key found: {}", key)] UnknownCargoFileKey { key: String },
+    #[fail(display = "Unknown cargo key found: {}", key)]
+    UnknownCargoFileKey { key: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,9 @@ use std::io::Error as IOError;
 
 #[derive(Fail, Debug)]
 pub enum FatalError {
-    #[fail(display = "{}", _0)]
-    IO(#[cause] IOError),
+    #[fail(display = "{}", _0)] IO(#[cause] IOError),
 
-    #[fail(display = "Invalid cargo file format.")]
-    InvalidCargoFileFormat,
+    #[fail(display = "Invalid cargo file format.")] InvalidCargoFileFormat,
 
-    #[fail(display = "Unknown cargo key found: {}", key)]
-    UnknownCargoFileKey { key: String },
+    #[fail(display = "Unknown cargo key found: {}", key)] UnknownCargoFileKey { key: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,29 +1,13 @@
 use std::io::Error as IOError;
-use std::string::FromUtf8Error;
-use cargo::CargoError;
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum FatalError {
-        IOError(err: IOError) {
-            from()
-            cause(err)
-        }
-        InvalidCargoFileFormat {
-            display("Invalid cargo file format.")
-            description("Invalid cargo file format.")
-        }
-        UnknownCargoFileKey(key: String) {
-            display("Unknown cargo key found: {}", key)
-            description("Unknown config key found.")
-        }
-        CargoError(err: CargoError) {
-            from()
-            cause(err)
-        }
-        FromUtf8Error(err: FromUtf8Error) {
-            from()
-            cause(err)
-        }
-    }
+#[derive(Fail, Debug)]
+pub enum FatalError {
+    #[fail(display = "{}", _0)]
+    IO(#[cause] IOError),
+
+    #[fail(display = "Invalid cargo file format.")]
+    InvalidCargoFileFormat,
+
+    #[fail(display = "Unknown cargo key found: {}", key)]
+    UnknownCargoFileKey { key: String },
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,13 +5,10 @@ use cmd::call;
 use failure::Error;
 
 pub fn remote_get_url(remote: &str) -> Result<String, Error> {
-    let output = try!(
-        Command::new("git")
-            .arg("remote")
-            .arg("get-url")
-            .arg(remote)
-            .output()
-    );
+    let output = try!(Command::new("git").arg("remote")
+                                         .arg("get-url")
+                                         .arg(remote)
+                                         .output());
 
     let url = try!(String::from_utf8(output.stdout));
     Ok(url)
@@ -25,27 +22,23 @@ pub fn add_all(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Erro
     call(&["git", "add", "."], dir, shell, dry_run)
 }
 
-pub fn commit_all(
-    dir: &str,
-    msg: &str,
-    sign: bool,
-    shell: &mut Shell,
-    dry_run: bool,
-) -> Result<bool, Error> {
-    call(
-        &["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
-        dir,
-        shell,
-        dry_run,
-    )
+pub fn commit_all(dir: &str,
+                  msg: &str,
+                  sign: bool,
+                  shell: &mut Shell,
+                  dry_run: bool)
+                  -> Result<bool, Error> {
+    call(&["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
+         dir,
+         shell,
+         dry_run)
 }
 
-pub fn force_push(
-    dir: &str,
-    remote: &str,
-    refspec: &str,
-    shell: &mut Shell,
-    dry_run: bool,
-) -> Result<bool, Error> {
+pub fn force_push(dir: &str,
+                  remote: &str,
+                  refspec: &str,
+                  shell: &mut Shell,
+                  dry_run: bool)
+                  -> Result<bool, Error> {
     call(&["git", "push", "-f", remote, refspec], dir, shell, dry_run)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,10 +5,13 @@ use cmd::call;
 use failure::Error;
 
 pub fn remote_get_url(remote: &str) -> Result<String, Error> {
-    let output = try!(Command::new("git").arg("remote")
-                                         .arg("get-url")
-                                         .arg(remote)
-                                         .output());
+    let output = try!(
+        Command::new("git")
+            .arg("remote")
+            .arg("get-url")
+            .arg(remote)
+            .output()
+    );
 
     let url = try!(String::from_utf8(output.stdout));
     Ok(url)
@@ -22,23 +25,27 @@ pub fn add_all(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Erro
     call(&["git", "add", "."], dir, shell, dry_run)
 }
 
-pub fn commit_all(dir: &str,
-                  msg: &str,
-                  sign: bool,
-                  shell: &mut Shell,
-                  dry_run: bool)
-                  -> Result<bool, Error> {
-    call(&["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
-         dir,
-         shell,
-         dry_run)
+pub fn commit_all(
+    dir: &str,
+    msg: &str,
+    sign: bool,
+    shell: &mut Shell,
+    dry_run: bool,
+) -> Result<bool, Error> {
+    call(
+        &["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
+        dir,
+        shell,
+        dry_run,
+    )
 }
 
-pub fn force_push(dir: &str,
-                  remote: &str,
-                  refspec: &str,
-                  shell: &mut Shell,
-                  dry_run: bool)
-                  -> Result<bool, Error> {
+pub fn force_push(
+    dir: &str,
+    remote: &str,
+    refspec: &str,
+    shell: &mut Shell,
+    dry_run: bool,
+) -> Result<bool, Error> {
     call(&["git", "push", "-f", remote, refspec], dir, shell, dry_run)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,10 +1,10 @@
 use std::process::Command;
 
-use cmd::call;
-use error::FatalError;
 use cargo::core::shell::Shell;
+use cmd::call;
+use failure::Error;
 
-pub fn remote_get_url(remote: &str) -> Result<String, FatalError> {
+pub fn remote_get_url(remote: &str) -> Result<String, Error> {
     let output = try!(
         Command::new("git")
             .arg("remote")
@@ -17,11 +17,11 @@ pub fn remote_get_url(remote: &str) -> Result<String, FatalError> {
     Ok(url)
 }
 
-pub fn init(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, FatalError> {
+pub fn init(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     call(&["git", "init"], dir, shell, dry_run)
 }
 
-pub fn add_all(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, FatalError> {
+pub fn add_all(dir: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     call(&["git", "add", "."], dir, shell, dry_run)
 }
 
@@ -31,7 +31,7 @@ pub fn commit_all(
     sign: bool,
     shell: &mut Shell,
     dry_run: bool,
-) -> Result<bool, FatalError> {
+) -> Result<bool, Error> {
     call(
         &["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
         dir,
@@ -46,6 +46,6 @@ pub fn force_push(
     refspec: &str,
     shell: &mut Shell,
     dry_run: bool,
-) -> Result<bool, FatalError> {
+) -> Result<bool, Error> {
     call(&["git", "push", "-f", remote, refspec], dir, shell, dry_run)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,15 +25,21 @@ use failure::{Error, SyncFailure};
 use termcolor::Color::{Blue, Green};
 
 fn build(docs_path: &str, shell: &mut Shell, dry_run: bool) -> Result<(), Error> {
-    try!(shell.verbose(|s| { s.status_with_color("", "Building Sphinx docs.", Blue) })
-              .map_err(SyncFailure::new));
+    try!(
+        shell
+            .verbose(|s| s.status_with_color("", "Building Sphinx docs.", Blue))
+            .map_err(SyncFailure::new)
+    );
     try!(call(&["make", "clean", "html"], docs_path, shell, dry_run));
 
     // A `.nojekyll` file prevents GitHub from ignoring Sphinx CSS files.
     let nojekyll = Path::new(docs_path).join("_build/html/.nojekyll");
     if dry_run {
-        try!(shell.status_with_color("", format!("touch {}", nojekyll.display()), Green)
-                  .map_err(SyncFailure::new));
+        try!(
+            shell
+                .status_with_color("", format!("touch {}", nojekyll.display()), Green)
+                .map_err(SyncFailure::new)
+        );
     } else if !nojekyll.exists() {
         try!(File::create(nojekyll));
     }
@@ -41,23 +47,33 @@ fn build(docs_path: &str, shell: &mut Shell, dry_run: bool) -> Result<(), Error>
     Ok(())
 }
 
-fn publish(docs_path: &str,
-           commit_msg: &str,
-           sign: bool,
-           push_remote: &str,
-           push_branch: &str,
-           shell: &mut Shell,
-           dry_run: bool)
-           -> Result<bool, Error> {
-    try!(shell.verbose(|s| {
-                           s.status_with_color("", "Publishing Sphinx docs to GitHub Pages.", Blue)
-                       })
-              .map_err(SyncFailure::new));
+fn publish(
+    docs_path: &str,
+    commit_msg: &str,
+    sign: bool,
+    push_remote: &str,
+    push_branch: &str,
+    shell: &mut Shell,
+    dry_run: bool,
+) -> Result<bool, Error> {
+    try!(
+        shell
+            .verbose(|s| {
+                s.status_with_color("", "Publishing Sphinx docs to GitHub Pages.", Blue)
+            })
+            .map_err(SyncFailure::new)
+    );
     let docs_build_path = format!("{}/_build/html", docs_path);
 
     try!(git::init(&docs_build_path, shell, dry_run));
     try!(git::add_all(&docs_build_path, shell, dry_run));
-    try!(git::commit_all(&docs_build_path, commit_msg, sign, shell, dry_run,));
+    try!(git::commit_all(
+        &docs_build_path,
+        commit_msg,
+        sign,
+        shell,
+        dry_run,
+    ));
     let remote = try!(git::remote_get_url(push_remote));
 
     let mut refspec = String::from("master:");
@@ -67,46 +83,56 @@ fn publish(docs_path: &str,
 }
 
 fn execute(args: &ArgMatches, cargo_config: &CargoConfig) -> Result<i32, Error> {
-    try!(cargo_config.configure(args.occurrences_of("verbose") as u32,
-                                Some(args.is_present("quiet")),
-                                &args.value_of("color").map(String::from),
-                                false,
-                                false,
-                                &[])
-                     .map_err(SyncFailure::new));
+    try!(
+        cargo_config
+            .configure(
+                args.occurrences_of("verbose") as u32,
+                Some(args.is_present("quiet")),
+                &args.value_of("color").map(String::from),
+                false,
+                false,
+                &[],
+            )
+            .map_err(SyncFailure::new)
+    );
 
     let config: Config = try!(Config::from("Cargo.toml"));
 
     // Find parameters or use defaults.
     let dry_run = args.is_present("dry-run");
 
-    let docs_path = args.value_of("docs-path").or_else(|| config.get_str(config::DOCS_PATH))
-                        .unwrap_or("docs");
+    let docs_path = args.value_of("docs-path")
+        .or_else(|| config.get_str(config::DOCS_PATH))
+        .unwrap_or("docs");
 
     let push = args.is_present("push");
 
-    let commit_msg =
-        args.value_of("commit-message").or_else(|| config.get_str(config::COMMIT_MESSAGE))
-            .unwrap_or("(cargo-sphinx) Generate docs.");
+    let commit_msg = args.value_of("commit-message")
+        .or_else(|| config.get_str(config::COMMIT_MESSAGE))
+        .unwrap_or("(cargo-sphinx) Generate docs.");
 
     let sign = args.is_present("sign") || config.get_bool(config::SIGN_COMMIT).unwrap_or(false);
 
-    let push_remote = args.value_of("push-remote").or_else(|| config.get_str(config::PUSH_REMOTE))
-                          .unwrap_or("origin");
+    let push_remote = args.value_of("push-remote")
+        .or_else(|| config.get_str(config::PUSH_REMOTE))
+        .unwrap_or("origin");
 
-    let push_branch = args.value_of("push-branch").or_else(|| config.get_str(config::PUSH_BRANCH))
-                          .unwrap_or("gh-pages");
+    let push_branch = args.value_of("push-branch")
+        .or_else(|| config.get_str(config::PUSH_BRANCH))
+        .unwrap_or("gh-pages");
 
     // Generate and publish documentation.
     try!(build(docs_path, &mut *cargo_config.shell(), dry_run));
     if push {
-        try!(publish(docs_path,
-                     commit_msg,
-                     sign,
-                     push_remote,
-                     push_branch,
-                     &mut *cargo_config.shell(),
-                     dry_run,));
+        try!(publish(
+            docs_path,
+            commit_msg,
+            sign,
+            push_remote,
+            push_branch,
+            &mut *cargo_config.shell(),
+            dry_run,
+        ));
     }
 
     Ok(0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,6 @@ use failure::{Error, SyncFailure};
 use termcolor::Color::{Blue, Green};
 
 fn build(docs_path: &str, shell: &mut Shell, dry_run: bool) -> Result<(), Error> {
-    // TODO: Remove the SyncFailure mapping once Cargo got updated. This is likely
-    // going to happen with Cargo 0.23.
     try!(
         shell
             .verbose(|s| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,23 +25,15 @@ use failure::{Error, SyncFailure};
 use termcolor::Color::{Blue, Green};
 
 fn build(docs_path: &str, shell: &mut Shell, dry_run: bool) -> Result<(), Error> {
-    try!(
-        shell
-            .verbose(|s| {
-                s.status_with_color("", "Building Sphinx docs.", Blue)
-            })
-            .map_err(SyncFailure::new)
-    );
+    try!(shell.verbose(|s| { s.status_with_color("", "Building Sphinx docs.", Blue) })
+              .map_err(SyncFailure::new));
     try!(call(&["make", "clean", "html"], docs_path, shell, dry_run));
 
     // A `.nojekyll` file prevents GitHub from ignoring Sphinx CSS files.
     let nojekyll = Path::new(docs_path).join("_build/html/.nojekyll");
     if dry_run {
-        try!(
-            shell
-                .status_with_color("", format!("touch {}", nojekyll.display()), Green)
-                .map_err(SyncFailure::new)
-        );
+        try!(shell.status_with_color("", format!("touch {}", nojekyll.display()), Green)
+                  .map_err(SyncFailure::new));
     } else if !nojekyll.exists() {
         try!(File::create(nojekyll));
     }
@@ -49,33 +41,23 @@ fn build(docs_path: &str, shell: &mut Shell, dry_run: bool) -> Result<(), Error>
     Ok(())
 }
 
-fn publish(
-    docs_path: &str,
-    commit_msg: &str,
-    sign: bool,
-    push_remote: &str,
-    push_branch: &str,
-    shell: &mut Shell,
-    dry_run: bool,
-) -> Result<bool, Error> {
-    try!(
-        shell
-            .verbose(|s| {
-                s.status_with_color("", "Publishing Sphinx docs to GitHub Pages.", Blue)
-            })
-            .map_err(SyncFailure::new)
-    );
+fn publish(docs_path: &str,
+           commit_msg: &str,
+           sign: bool,
+           push_remote: &str,
+           push_branch: &str,
+           shell: &mut Shell,
+           dry_run: bool)
+           -> Result<bool, Error> {
+    try!(shell.verbose(|s| {
+                           s.status_with_color("", "Publishing Sphinx docs to GitHub Pages.", Blue)
+                       })
+              .map_err(SyncFailure::new));
     let docs_build_path = format!("{}/_build/html", docs_path);
 
     try!(git::init(&docs_build_path, shell, dry_run));
     try!(git::add_all(&docs_build_path, shell, dry_run));
-    try!(git::commit_all(
-        &docs_build_path,
-        commit_msg,
-        sign,
-        shell,
-        dry_run,
-    ));
+    try!(git::commit_all(&docs_build_path, commit_msg, sign, shell, dry_run,));
     let remote = try!(git::remote_get_url(push_remote));
 
     let mut refspec = String::from("master:");
@@ -85,56 +67,46 @@ fn publish(
 }
 
 fn execute(args: &ArgMatches, cargo_config: &CargoConfig) -> Result<i32, Error> {
-    try!(
-        cargo_config
-            .configure(
-                args.occurrences_of("verbose") as u32,
-                Some(args.is_present("quiet")),
-                &args.value_of("color").map(String::from),
-                false,
-                false,
-                &[]
-            )
-            .map_err(SyncFailure::new)
-    );
+    try!(cargo_config.configure(args.occurrences_of("verbose") as u32,
+                                Some(args.is_present("quiet")),
+                                &args.value_of("color").map(String::from),
+                                false,
+                                false,
+                                &[])
+                     .map_err(SyncFailure::new));
 
     let config: Config = try!(Config::from("Cargo.toml"));
 
     // Find parameters or use defaults.
     let dry_run = args.is_present("dry-run");
 
-    let docs_path = args.value_of("docs-path")
-        .or_else(|| config.get_str(config::DOCS_PATH))
-        .unwrap_or("docs");
+    let docs_path = args.value_of("docs-path").or_else(|| config.get_str(config::DOCS_PATH))
+                        .unwrap_or("docs");
 
     let push = args.is_present("push");
 
-    let commit_msg = args.value_of("commit-message")
-        .or_else(|| config.get_str(config::COMMIT_MESSAGE))
-        .unwrap_or("(cargo-sphinx) Generate docs.");
+    let commit_msg =
+        args.value_of("commit-message").or_else(|| config.get_str(config::COMMIT_MESSAGE))
+            .unwrap_or("(cargo-sphinx) Generate docs.");
 
     let sign = args.is_present("sign") || config.get_bool(config::SIGN_COMMIT).unwrap_or(false);
 
-    let push_remote = args.value_of("push-remote")
-        .or_else(|| config.get_str(config::PUSH_REMOTE))
-        .unwrap_or("origin");
+    let push_remote = args.value_of("push-remote").or_else(|| config.get_str(config::PUSH_REMOTE))
+                          .unwrap_or("origin");
 
-    let push_branch = args.value_of("push-branch")
-        .or_else(|| config.get_str(config::PUSH_BRANCH))
-        .unwrap_or("gh-pages");
+    let push_branch = args.value_of("push-branch").or_else(|| config.get_str(config::PUSH_BRANCH))
+                          .unwrap_or("gh-pages");
 
     // Generate and publish documentation.
     try!(build(docs_path, &mut *cargo_config.shell(), dry_run));
     if push {
-        try!(publish(
-            docs_path,
-            commit_msg,
-            sign,
-            push_remote,
-            push_branch,
-            &mut *cargo_config.shell(),
-            dry_run,
-        ));
+        try!(publish(docs_path,
+                     commit_msg,
+                     sign,
+                     push_remote,
+                     push_branch,
+                     &mut *cargo_config.shell(),
+                     dry_run,));
     }
 
     Ok(0)


### PR DESCRIPTION
So, [failure](https://boats.gitlab.io/failure/intro.html) is the new hotness in Rust land and meant to replace quick-error and error-chain and I wanted to give it a try.

It is all pretty straightforward, but sadly Cargo's errors aren't fully compatible yet because they don't implement the `Sync` trait, which forces us to wrap them with `SyncFailure` - a helper that's in `failure` to assist with those transitions.