### PR TITLE
Download pre-compiled rustfmt-nightly binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache: cargo
 before_script:
   - |
     mkdir -p $HOME/.local/bin/ &&
-    curl -L -o $HOME/.local/bin/cargo-fmt https://github.com/woofwoofinc/rustfmt/releases/download/0.2.16/cargo-fmt.lnx64 &&
+    curl -s -L -o $HOME/.local/bin/cargo-fmt https://github.com/woofwoofinc/rustfmt/releases/download/0.2.16/cargo-fmt.lnx64 &&
     export PATH=$HOME/.local/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
 cache: cargo
 before_script:
   - |
-    (cargo install rustfmt || true) &&
-    export PATH=$HOME/.cargo/bin:$PATH
+    mkdir -p $HOME/.local/bin/ &&
+    curl -L -o $HOME/.local/bin/cargo-fmt https://github.com/woofwoofinc/rustfmt/releases/download/0.2.16/cargo-fmt.lnx64 &&
+    export PATH=$HOME/.local/bin:$PATH
 
 script:
   - |


### PR DESCRIPTION
I've forked the `rustfmt-nightly` repo to `woofwoofinc` and uploaded a Linux binary to the release page.

Saves us some time in the Travis run too.