### PR TITLE
[ci] Update cargo-fmt use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - |
-    cargo +nightly fmt -- --write-mode=diff &&
+    cargo +nightly fmt -- --check &&
     cargo build &&
     cargo test
 addons:


### PR DESCRIPTION
Looks like `--write-mode` is gone. `--check` now returns an exit
code based on whether everything is correctly formatted or not.