### PR TITLE
Use stable rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ matrix:
     - rust: nightly
 cache: cargo
 before_script:
-  - |
-    rustup install nightly &&
-    cargo +nightly install rustfmt-nightly --force
+  - rustup component add rustfmt
 
 script:
   - |
-    cargo +nightly fmt -- --check &&
+    cargo fmt -- --check &&
     cargo build &&
     cargo test
 addons:


### PR DESCRIPTION
The old version stopped compiling in Travis, but worry not because `rustfmt` is now stable! 🚀

Even better, it's now guaranteed to keep the format stable.