### PR TITLE
Add error message notice for missing documentation directory. Fixes #83.

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,6 +1,7 @@
 use cargo::core::shell::Shell;
 use cargo::core::shell::Verbosity::{Normal, Quiet, Verbose};
 use failure::Error;
+use std::path::Path;
 use std::process::Command;
 use termcolor::Color::Green;
 
@@ -9,6 +10,15 @@ use termcolor::Color::Green;
 /// only execute the command if a dry run has not been requested.
 ///
 pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
+    if !Path::new(path).exists() {
+        shell.error(format!(
+            "Documentation path '{}' not present. \
+             Was this included as argument to `sphinx-generate`?",
+            path
+        ))?;
+        return Ok(false);
+    }
+
     if dry_run {
         shell.status_with_color("", format!("cd {}", path), Green)?;
         shell.status_with_color("", command.join(" "), Green)?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -14,7 +14,8 @@ pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> R
     if !Path::new(path).exists() {
         return Err(FatalError::DocumentationPathNotPresent {
             path: path.to_string(),
-        }.into());
+        }
+        .into());
     }
 
     if dry_run {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,3 +1,4 @@
+use crate::error::FatalError;
 use cargo::core::shell::Shell;
 use cargo::core::shell::Verbosity::{Normal, Quiet, Verbose};
 use failure::Error;
@@ -11,12 +12,9 @@ use termcolor::Color::Green;
 ///
 pub fn call(command: &[&str], path: &str, shell: &mut Shell, dry_run: bool) -> Result<bool, Error> {
     if !Path::new(path).exists() {
-        shell.error(format!(
-            "Documentation path '{}' not present. \
-             Was this included as argument to `sphinx-generate`?",
-            path
-        ))?;
-        return Ok(false);
+        return Err(FatalError::DocumentationPathNotPresent {
+            path: path.to_string(),
+        }.into());
     }
 
     if dry_run {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,4 +10,11 @@ pub enum FatalError {
 
     #[fail(display = "Unknown cargo key found: {}", key)]
     UnknownCargoFileKey { key: String },
+
+    #[fail(
+        display = "Documentation path '{}' not present. \
+                   Was this included as argument to `sphinx-generate`?",
+        path
+    )]
+    DocumentationPathNotPresent { path: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ pub enum FatalError {
 
     #[fail(
         display = "Documentation path '{}' not present. \
-                   Was this included as argument to `sphinx-generate`?",
+                   Was this included as argument to `sphinx-quickstart`?",
         path
     )]
     DocumentationPathNotPresent { path: String },


### PR DESCRIPTION
Error scenario now includes message line for missing documentation path.

```
   $ cargo new project
   $ cd project
   $ sphinx-quickstart
   $ cargo sphinx
   error: Documentation path 'docs' not present. Was this included as argument to `sphinx-generate`?
```